### PR TITLE
Transform NOTE_ON with velocity=0 into NOTE_OFF

### DIFF
--- a/aiotone/fmsynth.py
+++ b/aiotone/fmsynth.py
@@ -660,7 +660,10 @@ async def midi_consumer(queue: asyncio.Queue[MidiMessage], synth: Synthesizer) -
             elif t == STOP:
                 await synth.stop()
             elif t == NOTE_ON:
-                await synth.note_on(msg[1], msg[2])
+                if msg[2] == 0: # velocity of zero means "note off"
+                    await synth.note_off(msg[1], msg[2])
+                else:
+                    await synth.note_on(msg[1], msg[2])
             elif t == NOTE_OFF:
                 await synth.note_off(msg[1], msg[2])
             elif t == CONTROL_CHANGE:


### PR DESCRIPTION
Many devices use NOTE_ON with velocity=0 instead of NOTE_OFF.
It's an heritage of "MIDI Running Status".