### PR TITLE
Allow miniaudio backend selection

### DIFF
--- a/aiotone/aiotone-fmsynth.ini
+++ b/aiotone/aiotone-fmsynth.ini
@@ -12,3 +12,10 @@ out-name = BlackHole 16ch
 sample-rate = 48000
 buffer-msec = 3
 polyphony = 6
+
+# On Linux, this should use the default Pulseaudio output
+# out-name = Built-in Audio Analog Stereo
+
+# But with some hardware, you might get better results with ALSA, e.g.:
+# backend = ALSA
+# out-name = HDA Intel PCH, ALC293 Analog

--- a/aiotone/fmsynth.py
+++ b/aiotone/fmsynth.py
@@ -744,7 +744,14 @@ def main(config: str, make_config: bool) -> None:
     cfg = configparser.ConfigParser()
     cfg.read(config)
 
-    devices = miniaudio.Devices()
+    # Apparently, miniaudio (at least on Linux) doesn't enumerate devices across all backends.
+    # So if we want to use a device on a non-default backend, we need to specify the backend.
+    backend_name = cfg["audio-out"].get("backend")
+    if backend_name:
+        backend = getattr(miniaudio.Backend, backend_name)
+        devices = miniaudio.Devices([backend])
+    else:
+        devices = miniaudio.Devices()
     playbacks = devices.get_playbacks()
     audio_out = cfg["audio-out"]["out-name"]
     sample_rate = cfg["audio-out"].getint("sample-rate")


### PR DESCRIPTION
On Linux, the default backend seems to be Pulseaudio,
and in some circumstances (hardware/software combos)
it doesn't perform very well (crackling will be heard
with more than a few voices). ALSA can sometimes yield
much better performance. This patch allows changing
the backend.